### PR TITLE
Add copy as markdown feature to Share page

### DIFF
--- a/app/lib/markdown-export.ts
+++ b/app/lib/markdown-export.ts
@@ -1,0 +1,25 @@
+/**
+ * Formats a recipe for export to Obsidian or other markdown note-taking apps
+ */
+export function formatRecipeForObsidian(
+	formattedText: string,
+	recipeId: string,
+	createdAt: Date,
+	shareUrl: string,
+): string {
+	// Extract title from first H1 heading
+	const titleMatch = formattedText.match(/^#\s+(.+)$/m)
+	const title = titleMatch ? titleMatch[1] : "Unknown"
+
+	const dateStr = createdAt.toISOString().split("T")[0]
+
+	const frontmatter = `---
+title: ${title}
+created: ${dateStr}
+source: ${shareUrl}
+---
+
+`
+
+	return frontmatter + formattedText
+}

--- a/app/r/[id]/SharedRecipePage.tsx
+++ b/app/r/[id]/SharedRecipePage.tsx
@@ -2,8 +2,9 @@
 
 import Image from "next/image"
 import Link from "next/link"
-import { useState } from "react"
+import { useState, useEffect, useRef } from "react"
 import MarkdownRenderer from "@/app/components/MarkdownRenderer"
+import { formatRecipeForObsidian } from "@/app/lib/markdown-export"
 
 interface Recipe {
 	id: string
@@ -18,17 +19,54 @@ interface SharedRecipePageProps {
 
 export default function SharedRecipePage({ recipe }: SharedRecipePageProps) {
 	const [copySuccess, setCopySuccess] = useState(false)
+	const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+	const dropdownRef = useRef<HTMLDivElement>(null)
 
 	const shareUrl = `${typeof window !== "undefined" ? window.location.href : ""}`
 
-	const copyToClipboard = async () => {
+	// Close dropdown when clicking outside
+	useEffect(() => {
+		function handleClickOutside(event: MouseEvent) {
+			if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+				setIsDropdownOpen(false)
+			}
+		}
+
+		if (isDropdownOpen) {
+			document.addEventListener("mousedown", handleClickOutside)
+			return () => {
+				document.removeEventListener("mousedown", handleClickOutside)
+			}
+		}
+	}, [isDropdownOpen])
+
+	const copyUrlToClipboard = async () => {
 		try {
 			await navigator.clipboard.writeText(shareUrl)
 			setCopySuccess(true)
+			setIsDropdownOpen(false)
 			setTimeout(() => setCopySuccess(false), 2000)
 		} catch (error) {
-			console.error("Failed to copy to clipboard:", error)
-			alert("Failed to copy to clipboard")
+			console.error("Failed to copy URL to clipboard:", error)
+			alert("Failed to copy URL to clipboard")
+		}
+	}
+
+	const copyMarkdownToClipboard = async () => {
+		try {
+			const markdown = formatRecipeForObsidian(
+				recipe.formattedText,
+				recipe.id,
+				recipe.createdAt,
+				shareUrl,
+			)
+			await navigator.clipboard.writeText(markdown)
+			setCopySuccess(true)
+			setIsDropdownOpen(false)
+			setTimeout(() => setCopySuccess(false), 2000)
+		} catch (error) {
+			console.error("Failed to copy markdown to clipboard:", error)
+			alert("Failed to copy markdown to clipboard")
 		}
 	}
 
@@ -60,46 +98,119 @@ export default function SharedRecipePage({ recipe }: SharedRecipePageProps) {
 								Shared on {new Date(recipe.createdAt).toLocaleDateString()}
 							</p>
 						</div>
-						<button
-							type="button"
-							onClick={copyToClipboard}
-							className="bg-gray-800 hover:bg-gray-700 text-white p-2 rounded-md transition-colors flex items-center justify-center min-w-[40px]"
-							title={copySuccess ? "Copied!" : "Share This Recipe"}
-						>
-							{copySuccess ? (
-								<svg
-									className="w-5 h-5 text-green-400"
-									fill="none"
-									stroke="currentColor"
-									viewBox="0 0 24 24"
-									role="img"
-									aria-label="Copied"
-								>
-									<path
-										strokeLinecap="round"
-										strokeLinejoin="round"
-										strokeWidth={2}
-										d="M5 13l4 4L19 7"
-									/>
-								</svg>
-							) : (
-								<svg
-									className="w-5 h-5"
-									fill="none"
-									stroke="currentColor"
-									viewBox="0 0 24 24"
-									role="img"
-									aria-label="Share"
-								>
-									<path
-										strokeLinecap="round"
-										strokeLinejoin="round"
-										strokeWidth={2}
-										d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z"
-									/>
-								</svg>
+						<div className="relative" ref={dropdownRef}>
+							<button
+								type="button"
+								onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+								className="bg-gray-800 hover:bg-gray-700 text-white px-3 py-2 rounded-md transition-colors flex items-center gap-2"
+								title={copySuccess ? "Copied!" : "Share This Recipe"}
+							>
+								{copySuccess ? (
+									<>
+										<svg
+											className="w-5 h-5 text-green-400"
+											fill="none"
+											stroke="currentColor"
+											viewBox="0 0 24 24"
+											role="img"
+											aria-label="Copied"
+										>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												strokeWidth={2}
+												d="M5 13l4 4L19 7"
+											/>
+										</svg>
+										<span className="text-sm font-medium text-green-400">Copied!</span>
+									</>
+								) : (
+									<>
+										<svg
+											className="w-5 h-5"
+											fill="none"
+											stroke="currentColor"
+											viewBox="0 0 24 24"
+											role="img"
+											aria-label="Share"
+										>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												strokeWidth={2}
+												d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z"
+											/>
+										</svg>
+										<span className="text-sm font-medium">Share</span>
+										<svg
+											className="w-4 h-4"
+											fill="none"
+											stroke="currentColor"
+											viewBox="0 0 24 24"
+											role="img"
+											aria-label="Dropdown"
+										>
+											<path
+												strokeLinecap="round"
+												strokeLinejoin="round"
+												strokeWidth={2}
+												d="M19 9l-7 7-7-7"
+											/>
+										</svg>
+									</>
+								)}
+							</button>
+							{isDropdownOpen && !copySuccess && (
+								<div className="absolute right-0 mt-2 w-56 bg-gray-800 border border-gray-600 rounded-md shadow-lg z-10">
+									<div className="py-1">
+										<button
+											type="button"
+											onClick={copyUrlToClipboard}
+											className="w-full text-left px-4 py-2 text-sm text-white hover:bg-gray-700 flex items-center gap-2"
+										>
+											<svg
+												className="w-4 h-4"
+												fill="none"
+												stroke="currentColor"
+												viewBox="0 0 24 24"
+												role="img"
+												aria-label="Link"
+											>
+												<path
+													strokeLinecap="round"
+													strokeLinejoin="round"
+													strokeWidth={2}
+													d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+												/>
+											</svg>
+											Copy Share Link
+										</button>
+										<button
+											type="button"
+											onClick={copyMarkdownToClipboard}
+											className="w-full text-left px-4 py-2 text-sm text-white hover:bg-gray-700 flex items-center gap-2"
+										>
+											<svg
+												className="w-4 h-4"
+												fill="none"
+												stroke="currentColor"
+												viewBox="0 0 24 24"
+												role="img"
+												aria-label="Markdown"
+											>
+												<path
+													strokeLinecap="round"
+													strokeLinejoin="round"
+													strokeWidth={2}
+													d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+												/>
+											</svg>
+											Copy as Markdown
+										</button>
+									</div>
+								</div>
 							)}
-						</button>
+						</div>
 					</div>
 
 					<div className="bg-gray-900 border border-gray-600 rounded-md p-4 sm:p-6">


### PR DESCRIPTION
Implements a combi-dropdown button on the Share page that allows users to either:
- Copy the share link (existing functionality)
- Copy recipe as markdown with YAML frontmatter for Obsidian

Key changes:
- New markdown-export.ts utility that formats recipes with YAML frontmatter
- Frontmatter includes: title (extracted from first H1), creation date, and source URL
- SharedRecipePage.tsx updated with dropdown UI using relative positioning
- Click-outside detection to close dropdown automatically
- Both copy options show unified success feedback (checkmark + "Copied!")
- Falls back to "Unknown" title if no H1 heading found in recipe

UI improvements:
- Button now displays "Share" text label with dropdown arrow
- Dropdown menu shows both options with appropriate icons
- Maintains existing dark theme styling and visual feedback patterns
- Mobile-responsive design with proper z-index layering